### PR TITLE
fix the tranvis bug that run the command fail because of the license …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_install:
   - sudo apt-get -y install python3-pip python-dev


### PR DESCRIPTION
…problem of oraclejdk8 (#699)

## Summary
<!--Describe the change berifly-->

## Issue Type
<!--Pick one below and delete the rest-->
- New Feature
- Bug fixing

## Starter Names
  <!--Which Spring boot starters the change involves, pick items below and delete the rest-->
  - active directory spring boot starter
  - documentdb spring boot starter
  - key vault spring boot starter
  - media services spring boot starter
  - service bus spring boot starter
  - storage spring boot starter

## Additional Information